### PR TITLE
Replace buying link to aliexpress

### DIFF
--- a/site/content/device/ds248x.md
+++ b/site/content/device/ds248x.md
@@ -29,7 +29,8 @@ func main() {
 
 # Buying
 
-- Adafruit: [adafruit.com/?q=ds2483](https://www.adafruit.com/?q=ds2483)
-
+- Aliexpress:
+  [aliexpress.com/wholesale?SearchText=ds2483](https://aliexpress.com/wholesale?SearchText=ds2483)
+  
 _The periph authors do not endorse any specific seller. These are only provided
 for your convenience._


### PR DESCRIPTION
Adafruit doesn't sell this chip and the link leads to a breakout with a very similar name DS2413 but different functionality.
Remove the link to avoid frustrated buyers of the the wrong device.