### PR TITLE
Fix link formatting

### DIFF
--- a/site/content/project/contributing.md
+++ b/site/content/project/contributing.md
@@ -73,5 +73,5 @@ email directly `conduct@maruel.ca` for issues encountered.
 # The small print
 
 Contributions made by corporations are covered by a different agreement than
-the one above, the [Software Grant and Corporate Contributor License Agreement]
-(https://cla.developers.google.com/about/google-corporate).
+the one above, the [Software Grant and Corporate Contributor License
+Agreement](https://cla.developers.google.com/about/google-corporate).


### PR DESCRIPTION
Putting a newline between the `[]` and `()` prevents the MarkDown processor from parsing this as a link.